### PR TITLE
Add user role hook and constant for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Changelog
 
+1.2 -- Added API key constant and hook for user role
+
 1.1 -- 3/1/23 updated Vue dependency because the initial version cdn location has been discontinued
 
 1.0 -- Initial version

--- a/pantheon-agcdn-mgmt.php
+++ b/pantheon-agcdn-mgmt.php
@@ -3,7 +3,7 @@
  * Plugin Name: AGCDN Management
  * Plugin URI: https://pantheon.io
  * Description: Manage AGCDN Options
- * Version: 1.1
+ * Version: 1.2
  * Author: Pantheon
  * Author URI: https://pantheon.io
  *
@@ -16,6 +16,10 @@
  * @return void
  */
 function pantheon_agcdn_management_init() {
+	if ( ! empty( pantheon_agcdn_get_api_key_constant() ) ) {
+		return;
+	}
+
 	register_setting(
 		'pantheon_agcdn_management_settings',
 		'pantheon_agcdn_management_api_key',
@@ -61,7 +65,13 @@ function pantheon_agcdn_management_sanitize( $input ) {
  * @return void
  */
 function pantheon_agcdn_management_admin_menu() {
-	add_options_page( __( 'AGCDN Management' ), __( 'AGCDN Management' ), 'manage_options', 'pantheon-agcdn-management', 'view_settings_page' );
+	add_options_page(
+		__( 'AGCDN Management' ),
+		__( 'AGCDN Management' ),
+		apply_filters( 'pantheon_agcdn_management_user_role', 'manage_options' ),
+		'pantheon-agcdn-management',
+		'pantheon_agcdn_view_settings_page'
+	);
 }
 add_action( 'admin_menu', 'pantheon_agcdn_management_admin_menu' );
 
@@ -70,7 +80,14 @@ add_action( 'admin_menu', 'pantheon_agcdn_management_admin_menu' );
  *
  * @return void
  */
-function view_settings_page() {
+function pantheon_agcdn_view_settings_page() {
+	$api_key_constant = pantheon_agcdn_get_api_key_constant();
+	if ( ! empty( $api_key_constant ) ) {
+		$api_key = $api_key_constant;
+	} else {
+		$api_key = get_option( 'pantheon_agcdn_management_api_key' );
+	}
+
 	wp_enqueue_script( 'vue', 'https://cdn.jsdelivr.net/npm/vue@2.6.12', array(), '', true );
 	wp_enqueue_script( 'pantheon-agcdn-management', 'https://cdn.jsdelivr.net/gh/pantheon-systems/vue-agcdn-mgmt@0.9.5/dist/main.js', array( 'vue' ), '0.9.5', true );
 	wp_localize_script(
@@ -78,23 +95,39 @@ function view_settings_page() {
 		'WP_OPTIONS',
 		array(
 			'nonce'                             => wp_create_nonce( 'agcdn_mgmt' ),
-			'pantheon_agcdn_management_api_key' => get_option( 'pantheon_agcdn_management_api_key' ),
+			'pantheon_agcdn_management_api_key' => $api_key,
 		)
 	);
 
 	?>
 	<div class="wrap">
 		<h2>AGCDN Management Options</h2>
-		<form action="options.php" method="post">
-			<?php
+
+		<?php if ( empty( $api_key_constant ) ) : ?>
+			<form action="options.php" method="post">
+				<?php
 				settings_fields( 'pantheon_agcdn_management_settings' );
 				do_settings_sections( 'pantheon-agcdn-management' );
 				submit_button();
-			?>
-		</form>
+				?>
+			</form>
+		<?php endif; ?>
+
 		<div id="app">
 			<p>Loading...</p>
 		</div>
 	</div>
 	<?php
+}
+
+/**
+ * Check if API key constant is defined.
+ *
+ * @return string
+ */
+function pantheon_agcdn_get_api_key_constant() {
+	if ( defined( 'PANTHEON_AGCDN_MANAGEMENT_API_KEY' ) && ! empty( PANTHEON_AGCDN_MANAGEMENT_API_KEY ) ) {
+		return PANTHEON_AGCDN_MANAGEMENT_API_KEY;
+	}
+	return '';
 }


### PR DESCRIPTION
* Added a new hook `pantheon_agcdn_management_user_role` so we can set which user role should get access to this. Defaults to `manage_options` as it is now
* Allow setting a `PANTHEON_AGCDN_MANAGEMENT_API_KEY` constant so that we can add an API key using `wp-config.php` or similar: `define( 'PANTHEON_AGCDN_MANAGEMENT_API_KEY', 'xxxx' )`

Fixes #4 